### PR TITLE
Add Tim Chen's training step time to leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 
 | Name           | Training Step Time (ms) | Verification status (leave empty) |
 | :------------- | ----------------------: | --------------------------------: |
+| Tim Chen  |                 6199 ms |                                   | 
 | Tushar Dalmia  |                 8133 ms |                                   | 
 | naive baseline |                10000 ms |                          Verified |
 


### PR DESCRIPTION
What I added:

- Flash Attention Trition backward pass
    - Two kernels for the backward pass, one for dQ, and one for dK and dV
- FlashAttention - skipping tiles that are guaranteed to be all zero
- ~~FlashAttention - Separate the non-masked tiles from the tile diagonals, computing the first without ever comparing indices, and the second with a single comparison~~ (not used actually as it increased total time)
- Improved ROPE (improve caching and stacking speed)
- Triton autotune the three kernels
- Gradient Checkpointing (block size = 1) 
    - Add extra code for FSDP to support gradient checkpointing
- Fused AdamW, implemented in Triton
- Torch.compile the model

Best Avg Wall-clock time:  6.1994s (6199.4254150390625 ms)