### PR TITLE
Add Javier Nieto's performance timing to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 | Tim Chen  |                 6199 ms |                                   | 
 | Aniket Gupta   |                 6237 ms |                                   | 
 | Tushar Dalmia  |                 8133 ms |                                   | 
+| Javier Nieto  |                 8829 ms |                                   | 
 | Jason Meng     |                 9555 ms |                                   | 
 | naive baseline |                10000 ms |                          Verified |
 


### PR DESCRIPTION
What I did:
- Backward FlashAttention kernel following the algorithm in the PDF given.
- FlashAttention Kernel skips tiles it knows it will mask.
- Increase tile size to 128x128 for forward and 64x64 for backward (I probably could optimize this further but I don't have the time).
- Checkpointing each pair of layers.
- Pytorch compile with fullgraph, removing the python logic that could cause graph breaks.