### PR TITLE
add tanush score

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 | Tim Chen  |                 6199 ms |                                   | 
 | Aniket Gupta   |                 6237 ms |                                   | 
 | Tushar Dalmia  |                 8133 ms |                                   | 
+| Tanush Talati  |                 8794 ms |                                   | 
 | Jason Meng     |                 9555 ms |                                   | 
 | naive baseline |                10000 ms |                          Verified |
 


### PR DESCRIPTION
Mainly for this I had to update my FSDP implementation to support checkpointing and also did activation checkpointing at every layer. I also had to update my pytorch implementation of the backward pass for flash-attention to basically tile on the Q dimension when computing the backward gradients instead of materializing all of the matrices at once since I was getting OOM errors. I wrapped this in a torch.compile annotation, which I assume helped compile it to faster kernels/CUDA implementations and hopefully also overlapped parallel compute. Also did mild triton autotune on my forward kernel

The wallclock time for this method: 8.794 seconds