### PR TITLE
Add Silin leaderboard result

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 | :------------- | ----------------------: | --------------------------------: |
 | Tim Chen  |                 6199 ms |                                   | 
 | Aniket Gupta   |                 6237 ms |                                   | 
-| Tushar Dalmia  |                 8133 ms |                                   | 
-| Jason Meng     |                 9555 ms |                                   | 
+| Tushar Dalmia  |                 8133 ms |                                  | 
+| Silin Du  |                 9083 ms |                                       | 
+| Jason Meng     |                 9555 ms |                                | 
 | naive baseline |                10000 ms |                          Verified |
 
 <details markdown="1">


### PR DESCRIPTION
Implemented a Triton kernel for the FlashAttention backward pass following the pseudocode from the assignment.

Tuned the FlashAttention tile sizes to Bq = 64 and Bk = 32.

Added causal all-zero tile skipping to avoid unnecessary computation for masked-out attention blocks.

Applied my previously implemented FSDP strategy to shard the model across the two GPUs.

Added activation checkpointing with checkpoint_block_size = 2.