### PR TITLE
Weiran Xu submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 
 | Name           | Training Step Time (ms) | Verification status (leave empty) |
 | :------------- | ----------------------: | --------------------------------: |
+| Weiran Xu      |                 6089 ms |                                   | 
 | Tim Chen       |                 6199 ms |                                   | 
 | Aniket Gupta   |                 6237 ms |                                   | 
 | Sara Kothari   |                 7431 ms |                                   | 


### PR DESCRIPTION
Triton Backward 2 pass: dQ and aKdV
Triton autotune
checkpoint every TransformerBlock
Skip masked out tiles in causal attention, and treat partially masked tiles differently