### PR TITLE
Add Yufei Liu's time to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 | Tanush Talati  |                 8794 ms |                                   | 
 | Javier Nieto   |                 8829 ms |                                   | 
 | Silin Du       |                 9083 ms |                                   | 
+| Yufei Liu      |                 9277 ms |                                   | 
 | Jason Meng     |                 9555 ms |                                   | 
 | naive baseline |                10000 ms |                          Verified |
 


### PR DESCRIPTION
Final Training Step Time: 9277.1797 ms

What I did:
- Tuned the tile sizes for the kernels using Triton autotune.
- Implemented fused AdamW.
- Implemented chunked LM head and cross-entropy loss.
- Implemented the backward pass in Triton using two passes and early stopping.
- Modified the FlashAttention Triton kernels to accept 4D strides.
- Selectively applied torch.compile to pure math modules.
- Added gradient checkpointing of the first 27 layers to avoid OOM.
- Added FSDP asynchronous prefetching.