### PR TITLE
leaderboard submission 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 | Tim Chen       |                 6199 ms |                                   | 
 | Aniket Gupta   |                 6237 ms |                                   | 
 | Sara Kothari   |                 7431 ms |                                   | 
+| Kehan Li       |                 7597 ms |                                   |
 | Tushar Dalmia  |                 8133 ms |                                   | 
 | Tanush Talati  |                 8794 ms |                                   | 
 | Javier Nieto   |                 8829 ms |                                   | 


### PR DESCRIPTION
# Main changes
- Wraps `BasicsTransformerLM` with the assignment FSDP implementation inside the leaderboard Modal job.
- Use PyTorch SDPA for causal attention to avoid materializing full attention score matrices.
- Adds activation checkpointing over transformer blocks to reduce activation memory.
- Fused LM-head cross entropy path behind `CS336_FUSED_LM_HEAD=1`, so the full`[batch, seq, vocab]` logits tensor is not materialized following idea section. 
- Extends FSDP gradient handling to accept shard-shaped gradients from the fused LM-head loss.

# Assumptions:
No major assumptions. 
- Hardware: one Modal node with 2x B200 GPUs.
- Distributed backend: NCCL, 2 local ranks, one rank per GPU.
- Precision: BF16.