### PR TITLE
Add Adam Alhousiki's training step time

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 | :------------- | ----------------------: | --------------------------------: |
 | Tim Chen       |                 6199 ms |                                   | 
 | Aniket Gupta   |                 6237 ms |                                   | 
+| Adam Alhousiki |                 6469 ms |                                   |
 | Sara Kothari   |                 7431 ms |                                   | 
 | Tushar Dalmia  |                 8133 ms |                                   | 
 | Tanush Talati  |                 8794 ms |                                   | 


### PR DESCRIPTION
Key optimizations.
• BF16 autocast for compute and the residual stream, with FP32 master weights and FP32 AdamW
optimizer state. Master weights are cast to BF16 only at use time inside FSDP, so cross-rank weight
all-gathers move BF16 bytes rather than FP32.
• FSDP across 2×B200, sharding parameters, gradients, and optimizer state. Per-rank parameter memory
drops from 32 GiB (FP32 full) to 16 GiB (FP32 sharded).
• Custom Triton FlashAttention-2 with @triton.autotune over Q-tile and K-tile sizes (six configs for
forward, four for the backward dQ and dK/dV kernels), causal early-exit so each program only iterates
the keys it can possibly attend to, and a two-pass backward (dQ in one kernel, dK/dV in another) to
avoid atomics.
• @torch._dynamo.disable applied to the flash-attention call. This prevents Inductor from tracing into
the custom Triton kernel during torch.compile, while still letting compile fuse RMSNorm, SwiGLU,
and residual ops in the rest of the block.
• torch.compile(mode="default") applied to each transformer block before FSDP wrapping. Compiling
at the block granularity (not whole model) plays nicely with FSDP’s parameter-gather hooks.
• Chunked cross-entropy (4096-token chunks) so the [B, T, V ] = [2, 32768, 151936] logits tensor’s gradient
never fully materializes during backward. Limits peak dlogits to roughly 2.4 GiB instead of 19.9 GiB.
• Activation checkpointing with chunk_size=1 (recompute every block in backward). This trades compute
for memory, but the alternative was OOM.