### PR TITLE
report shiye su leaderboard time

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 | :------------- | ----------------------: | --------------------------------: |
 | Tim Chen       |                 6199 ms |                                   | 
 | Aniket Gupta   |                 6237 ms |                                   | 
+| Shiye Su       |                 7006 ms |                                   | 
 | Sara Kothari   |                 7431 ms |                                   | 
 | Tushar Dalmia  |                 8133 ms |                                   | 
 | Tanush Talati  |                 8794 ms |                                   | 


### PR DESCRIPTION
7006 ms

Implemented FlashAttention backwards pass. Computed P twice, separately in two loops one for dQ and one for dK and dV.

FlashAttention implementation skipped over tiles masked out to zero.

Tile sizes fixed to 64 x 64.

Fused LM head and cross-entropy loss.

torch.compile() on the transformer.

torch.set_float32_matmul_precision("high")

Activation checkpointed every layer to save memory.

Used data parallel and sharded optimiser.
