### PR TITLE
Add Keshav Patel Keval's training step time

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 | :------------- | ----------------------: | --------------------------------: |
 | Tim Chen       |                 6199 ms |                                   | 
 | Aniket Gupta   |                 6237 ms |                                   | 
+| Keshav Patel Keval |             6476 ms |                                   |
 | Sara Kothari   |                 7431 ms |                                   | 
 | Tushar Dalmia  |                 8133 ms |                                   | 
 | Tanush Talati  |                 8794 ms |                                   | 


### PR DESCRIPTION
Training step time (based on triton benchmarking) of 6476.37255859375 millsecs. Here is what I used:

* Activation checkpointing with (14, 14, 6) transformer blocks
* FSDP with 2GPUs
* Triton kernel for Flash Attention backward pass with separate kernels for dQ and (dK, dV)
* Triton Autotune for FlashAttention forward and backward kernels
* Fused AdamW triton kernel