### PR TITLE
Add Asanshay Gupta submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 
 | Name           | Training Step Time (ms) | Verification status (leave empty) |
 | :------------- | ----------------------: | --------------------------------: |
+| Asanshay Gupta |                 5745 ms |                                   |
 | Tim Chen       |                 6199 ms |                                   | 
 | Aniket Gupta   |                 6237 ms |                                   | 
 | Sara Kothari   |                 7431 ms |                                   | 


### PR DESCRIPTION
Triton causal FlashAttention2:
- no full L×L score tensor;
- hardcoded best tile sizes after autotuning
- Per-block torch.compile where used
- activation checkpointing so backward is block-by-blocl
- MiniFSDP shards linear/embedding weights on dim 0 per rank
- BF16 for compute/all-gather and the
residual stream
- FP32 masters and AdamW state, gradient all-reduces before the step.
- Cross entropy in 4096-token chunks (matmul CE → backward → drop logits) so we never store full
[B, L, V ] logits.

Final time: 5745 ms