### PR TITLE
add Jenn's submission to leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 | Tushar Dalmia  |                 8133 ms |                                   | 
 | Tanush Talati  |                 8794 ms |                                   | 
 | Javier Nieto   |                 8829 ms |                                   | 
-| Silin Du       |                 9083 ms |                                   | 
-| Jason Meng     |                 9555 ms |                                   | 
+| Silin Du       |                 9083 ms |                                   |
+| Jenn Wang      |                 9542 ms |                                   |
+| Jason Meng     |                 9555 ms |                                   |
 | naive baseline |                10000 ms |                          Verified |
 
 <details markdown="1">


### PR DESCRIPTION
Wall-clock time: 9542 ms

Triton backward pass with parallel streams for dQ and dK/dV
Chunked linear cross-entropy
Activation checkpointing (6 layers per checkpoint)
FSDP with prefetching
torch compile