### PR TITLE
Updating Keshav Patel Keval's training step time

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 
 | Name           | Training Step Time (ms) | Verification status (leave empty) |
 | :------------- | ----------------------: | --------------------------------: |
+| Keshav Patel Keval |             3837 ms |                                   |
 | Max Liu        |                 3868 ms |                                   |
 | Nick Rui       |                 4998 ms |                                   | 
 | Aayush Gupta   |                 5174 ms |                                   |
@@ -45,7 +46,6 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 | Tim Chen       |                 6199 ms |                                   | 
 | Aniket Gupta   |                 6237 ms |                                   | 
 | Adam Alhousiki |                 6469 ms |                                   |
-| Keshav Patel Keval |             6476 ms |                                   |
 | Shiye Su       |                 7006 ms |                                   | 
 | Thomas Li      |                 7190 ms |                                   |
 | Sara Kothari   |                 7431 ms |                                   | 


### PR DESCRIPTION
This is an updated run. Did the following: 
* Activation checkpointing with 5 transformer blocks in each checkpoint, except the last 4 which are in one checkpoint
* FSDP (some modification to comply with checkpointing) with 2 GPUs
* Triton kernel for Flash Attention backward pass with separate kernels for dQ and (dK, dV)
* Flash Attention kernels optimized to skip non-causal tiles and only use index based comparison for diagonal tiles
* Base-2 math in the triton kernels for Flash Attention
* Triton Autotune for FlashAttention forward and backward kernels (benchmarking completes within 10 minutes)
* Fused AdamW triton kernel

Final testing time was 3837.2369559151784 millisec.