### PR TITLE
Added Bodo Wirth time to leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 | :------------- | ----------------------: | --------------------------------: |
 | Keshav Patel Keval |             3837 ms |                                   |
 | Max Liu        |                 3868 ms |                                   |
+| Bodo Wirth     |                 4728 ms |                                   |
 | Nick Rui       |                 4998 ms |                                   | 
 | Aayush Gupta   |                 5174 ms |                                   |
 | Tushar Aggarwal|                 5584 ms |                                   | 


### PR DESCRIPTION
Implemented flash attention backward pass in two kernels and stopped loop early for masking and treated the blocks on the diagonal differently in flash attention. 
Also added the kernel for fused AdamW and for the lm-head and cross entropy loss (not for the backward pass of this though because I left that in PyTorch and just compiled it).
Checkpointed in 14 layer chunks and used DDP. 
Handtuned triton tile sizes. 