### PR TITLE
Add Yuheng Wu submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 | Eric Chen      |                 8158 ms |                                   |
 | Jiaming Shen   |                 8453 ms |                                   |
 | Qinan Yu       |                 8503 ms |                                   |
+| Yuheng Wu      |                 8729 ms |                                   |
 | Tanush Talati  |                 8794 ms |                                   |
-| Yuheng Wu      |                 8800 ms |                                   |
 | Javier Nieto   |                 8829 ms |                                   | 
 | Silin Du       |                 9083 ms |                                   |
 | Yufei Liu      |                 9277 ms |                                   | 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 | Eric Chen      |                 8158 ms |                                   |
 | Jiaming Shen   |                 8453 ms |                                   |
 | Qinan Yu       |                 8503 ms |                                   |
-| Tanush Talati  |                 8794 ms |                                   | 
+| Tanush Talati  |                 8794 ms |                                   |
+| Yuheng Wu      |                 8800 ms |                                   |
 | Javier Nieto   |                 8829 ms |                                   | 
 | Silin Du       |                 9083 ms |                                   |
 | Yufei Liu      |                 9277 ms |                                   | 


### PR DESCRIPTION
8729 ms per training step on 2× B200

Implementation

- Custom Triton FlashAttention-2: single-pass forward, two backward kernels (separate dQ and dKV, no atomics)
- Tile sizes: forward Bq=128, Bk=64; backward Bq=Bk=64
- Gradient checkpointing on every TransformerBlock
- Fused AdamW
- DDP with synchronous per-tensor all_reduce
- bf16 weights
- Code: `cs336_systems/leaderboard.py` + `cs336_systems/flash.py`