### PR TITLE
James Chen Leaderboard Submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 | Tim Chen       |                 6199 ms |                                   | 
 | Aniket Gupta   |                 6237 ms |                                   | 
 | Adam Alhousiki |                 6469 ms |                                   |
+| James Chen     |                 6867 ms |                                   |
 | Shiye Su       |                 7006 ms |                                   | 
 | Thomas Li      |                 7190 ms |                                   |
 | Sara Kothari   |                 7431 ms |                                   | 


### PR DESCRIPTION
Wrote triton backward pass for flash attention instead of torch.compile

Skipped all zero tiles during causal masking

Autotuned tile sizes

Wrapped with FSDP

Minimized checkpointing (checkpoint on all but last 12)

Final time: 6867 ms