### PR TITLE
Add Subha Vadlamannati to global leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 | Yufei Liu      |                 9277 ms |                                   | 
 | Jenn Wang      |                 9542 ms |                                   |
 | Jason Meng     |                 9555 ms |                                   |
+| Subha Vadlamannati |             9805 ms |                                   |
 | naive baseline |                10000 ms |                          Verified |
 
 <details markdown="1">


### PR DESCRIPTION
What I did

- custom triton backward pass
- used FSDP
- activation checkpointing on every transformer block to fit the model in
- chunked cross entropy so we don't have to materialize the full log_softmax
