### PR TITLE
add Haoyue Xiao

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 | Aniket Gupta   |                 6237 ms |                                   | 
 | Adam Alhousiki |                 6469 ms |                                   |
 | James Chen     |                 6867 ms |                                   |
+| Haoyue Xiao    |                 6792 ms |                                   |
 | Shiye Su       |                 7006 ms |                                   | 
 | Thomas Li      |                 7190 ms |                                   |
 | Sara Kothari   |                 7431 ms |                                   | 


### PR DESCRIPTION
Modifications:
- FSDP on the model
- Uniform-sliced activation checkpointing with `chunk_size=sqrt(num_layers)`
- Compiled all the transformer blocks except customized fused `flash_atten` kernels
- Implemented forward and backward of triton `flash_atten` kernel
- Implemented fused `cross_entropy_loss`
- Implemented skip guarantee-zero tiles for `flash_atten` kernel in both forward and backward passes