### PR TITLE
Updated Bodo Wirth timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 | :------------- | ----------------------: | --------------------------------: |
 | Keshav Patel Keval |             3837 ms |                                   |
 | Max Liu        |                 3868 ms |                                   |
-| Bodo Wirth     |                 4728 ms |                                   |
+| Bodo Wirth     |                 4318 ms |                                   |
 | Naveen Kannan  |                 4757 ms |                                   |
 | Nick Rui       |                 4998 ms |                                   | 
 | Aayush Gupta   |                 5174 ms |                                   |


### PR DESCRIPTION
Changed to checkpointing the last 18 layers (kept the rest of the optimisations the same).