### PR TITLE
Add Varun Madan's time to the leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 | Aayush Gupta   |                 5174 ms |                                   |
 | Tushar Aggarwal|                 5584 ms |                                   | 
 | Asanshay Gupta |                 5745 ms |                                   |
+| Varun Madan    |                 5993 ms |                                   |
 | Weiran Xu      |                 6089 ms |                                   |
 | Tim Chen       |                 6199 ms |                                   | 
 | Aniket Gupta   |                 6237 ms |                                   | 


### PR DESCRIPTION
What I did:

- FlashAttention backward in Triton two passes (dQ kernel, dKV kernel) so no atomics
- Causal early-stop in fwd and both bwd kernels, skipping all-zero tiles past the diagonal 
- Dropped boundary_check on loads/stores since shapes are exact multiples of the tile size
- torch.compile on the inner model for fusion on the non-attention ops
- Activation checkpointing per transformer block to fit the 8B model in memory FSDP with FP32 master weights, BF16 compute, per-rank batch sharding

Achieved 5992.69 ms per step on 2 B200s