### PR TITLE
adding Jiaxin to leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 | Yuheng Wu      |                 8729 ms |                                   |
 | Tanush Talati  |                 8794 ms |                                   |
 | Javier Nieto   |                 8829 ms |                                   | 
+| Jiaxin Fang    |                 8903 ms |                                   |
 | Silin Du       |                 9083 ms |                                   |
 | Yufei Liu      |                 9277 ms |                                   | 
 | Jenn Wang      |                 9542 ms |                                   |


### PR DESCRIPTION
For the leaderboard submission, I implemented several optimizations to minimize wall-clock time per training step: a 

- Triton kernel for the flash attention backward pass
- fusion of the language model head with the cross-entropy loss to avoid materializing the full logit tensor
- flash attention causal masking optimizations by stopping program instances early by skipping tiles guaranteed to be all-zero. 

Together these optimizations reduced the training step time to 8903 ms on two B200 GPUs.
PS: Apologies for the late PR submission — my code and report were submitted on Gradescope on time:)