### PR TITLE
Gorn (Nattaput) Namchittai Leaderboard Submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 | Aayush Gupta   |                 5174 ms |                                   |
 | Tushar Aggarwal|                 5584 ms |                                   | 
 | Asanshay Gupta |                 5745 ms |                                   |
+| Gorn (Nattaput) Namchittai |     5993 ms |                                   |
 | Weiran Xu      |                 6089 ms |                                   |
 | Tim Chen       |                 6199 ms |                                   | 
 | Aniket Gupta   |                 6237 ms |                                   | 


### PR DESCRIPTION
Best time: 5874.30078125 ms. What I did: checkpointing in groups of 5 blocks (with the last 2 blocks left un-checkpointed). Triton FlashAttention backward kernels with autotune. causal tile-skipping in FlashAttention. Fused AdamW. FSDP. torch.compile on each FFN. 

(Note that this is not the same time as teh one I wrote in my writeup because I misunderstood the spec. For my writeup, I was actually training batch size 2 on each of 2 GPUs (effective batch 4) because that's what I thought the spec meant. This result for my leaderboard submission can be reproduced by adding two lines (labels = labels[rank].unsqueeze(0) plus targets = targets[rank].unsqueeze(0)) after line 53 in leaderboard.py in my code submission on gradescope and running uv run modal run cs336_systems/leaderboard.py::run_leaderboard)