### PR TITLE
Add Juntong Shi's timing to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 | Shiye Su       |                 7006 ms |                                   | 
 | Thomas Li      |                 7190 ms |                                   |
 | Sara Kothari   |                 7431 ms |                                   |
+| Juntong Shi    |                 7836 ms |                                   |
 | Lenard Strahringer    |          7979 ms |                                   |
 | Tushar Dalmia  |                 8133 ms |                                   | 
 | Alexandra Kim  |                 8135 ms |                                   |


### PR DESCRIPTION
- Implement flash-attention backward pass. This avoids materializing the whole attention weight matrix, which is gigantic with out long context
- Activation checkpointing on every transformer blocks. This avoids storing dense intermediate activations and reduces memory usage.

These two tricks reduce memory to fit within the B200 limit and achieve a step time of `7835.68ms`.