### PR TITLE
leaderboard andrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 | Nick Rui       |                 4998 ms |                                   | 
 | Nicole Ma      |                 5364 ms |                                   |
 | Tushar Aggarwal|                 5584 ms |                                   | 
+| Andrew Park    |                 5738 ms |                                   |
 | Asanshay Gupta |                 5745 ms |                                   |
 | Gorn (Nattaput) Namchittai |     5993 ms |                                   |
 | Varun Madan    |                 5993 ms |                                   |


### PR DESCRIPTION
- Triton FlashAttention-2 forward + backward kernels
- Two-pass backward
- Skip masked causal blocks; special-case diagonal blocks
- Autotuned tile sizes 
- 64×64 tuned for B200
- bf16 model + FSDP to cut casting overhead
- Activation checkpointing to fit memory
- Custom bf16 cross-entropy (skips fp32 log_softmax)
- Fused AdamW