### PR TITLE
Add Daphne Barretto's timing to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Stanford class leaderboard (Spring 2026) - 2 B200 GPUs
 | Tim Chen       |                 6199 ms |                                   | 
 | Aniket Gupta   |                 6237 ms |                                   | 
 | Adam Alhousiki |                 6469 ms |                                   |
+| Daphne Barretto|                 6606 ms |                                   |
 | James Chen     |                 6867 ms |                                   |
 | Haoyue Xiao    |                 6792 ms |                                   |
 | Nick Jiang     |                 6970 ms |                                   |


### PR DESCRIPTION
My best wall-clock time for a full forward-and-backward training step with AdamW is 6606.06542969ms. My strategy was to use use TritonFlashAttention2 with both forward and backward tiled kernels tuned with triton.autotune and skipping tiles guaranteed to be all zero, gradient checkpointing with sqrt(layers) number of checkpoints, FSDP, and ShardedOptimizer. My forward kernel was 32x32 tile sizes, backwards dkdv was 32x32 tile sizes, and backwards dq was 16x16 tile sizes.